### PR TITLE
Fixes: CodeQL 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,4 +1,6 @@
 name: Pyrogram - Mod
+permissions:
+  contents: read
 
 on: [push, pull_request]
 


### PR DESCRIPTION
Potential fix for [https://github.com/PyrogramMod/PyrogramMod/security/code-scanning/7](https://github.com/PyrogramMod/PyrogramMod/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow file `.github/workflows/python.yml`. The most general and minimal way to do this is to specify the `permissions` key at the top-level (just below the workflow `name`, typically), or at the job level if customized per job is desired. Since the workflow does not show any steps that require write permission (e.g., it doesn't push code, create releases, or modify pull requests), it's safe to set `contents: read`, which is the recommended minimal permission for workflows that only need to read repository contents. Insert `permissions: contents: read` immediately after the `name` field (before `on:`) or above `jobs:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
